### PR TITLE
ProxyScheduleCommand hopper command changes

### DIFF
--- a/src/main/java/frc/team3128/autonomous/AutoPrograms.java
+++ b/src/main/java/frc/team3128/autonomous/AutoPrograms.java
@@ -6,16 +6,15 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.ParallelDeadlineGroup;
+import edu.wpi.first.wpilibj2.command.ScheduleCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import frc.team3128.commands.CmdAlign;
 import frc.team3128.commands.CmdExtendIntake;
 import frc.team3128.commands.CmdExtendIntakeAndRun;
 import frc.team3128.commands.CmdInPlaceTurn;
-import frc.team3128.commands.CmdRetractHopper;
 import frc.team3128.commands.CmdShoot;
 import frc.team3128.commands.CmdShootAlign;
+import frc.team3128.commands.CmdShootAlignSingle;
 import frc.team3128.commands.CmdOuttake;
-import frc.team3128.commands.CmdShootSingleBall;
 import frc.team3128.commands.CmdShootTurnVision;
 import frc.team3128.common.narwhaldashboard.NarwhalDashboard;
 import frc.team3128.common.utility.Log;
@@ -80,10 +79,7 @@ public class AutoPrograms {
                 autoCommand = new SequentialCommandGroup(
                                     new InstantCommand(() -> intake.ejectIntake(), intake),
 
-                                    new ParallelDeadlineGroup(
-                                        trajectoryCmd("twoBallTraj"), 
-                                        new CmdExtendIntakeAndRun()
-                                    ),
+                                    IntakePathCmd("twoBallTraj"),
 
                                     new CmdInPlaceTurn(180),
 
@@ -114,7 +110,7 @@ public class AutoPrograms {
                                 //drive to ball and terminal and intake
                                 IntakePathCmd("4Ball_Terminal180_ii"), 
 
-                                new CmdExtendIntakeAndRun().withTimeout(1),
+                                new CmdExtendIntakeAndRun().withTimeout(1), // is this still needed?
 
                                 //drive to tarmac and shoot
                                 trajectoryCmd("Terminal2Tarmac"),
@@ -204,11 +200,7 @@ public class AutoPrograms {
                                 //turn and shoot 1 ball
                                 new CmdInPlaceTurn(180),
                                 
-                                new CmdRetractHopper(),
-                                new ParallelCommandGroup(
-                                    new CmdAlign(),
-                                    new CmdShootSingleBall()
-                                ).withTimeout(2),
+                                new CmdShootAlignSingle().withTimeout(2),
                                 
                                 //hide enemy ball behind hub
                                 trajectoryCmd("S1H1_ii"),
@@ -225,11 +217,7 @@ public class AutoPrograms {
                                 //turn and shoot 1 ball
                                 new CmdInPlaceTurn(180),
                                 
-                                new CmdRetractHopper(),
-                                new ParallelCommandGroup(
-                                    new CmdAlign(),
-                                    new CmdShootSingleBall()
-                                ).withTimeout(2),
+                                new CmdShootAlignSingle().withTimeout(2),
 
                                 //drive and intake enemy ball
                                 IntakePathCmd("S1H2_ii"), 
@@ -252,11 +240,7 @@ public class AutoPrograms {
                                 //turn and shoot 1 ball
                                 new CmdInPlaceTurn(180),
                                 
-                                new CmdRetractHopper(),
-                                new ParallelCommandGroup(
-                                    new CmdAlign(),
-                                    new CmdShootSingleBall()
-                                ).withTimeout(2));
+                                new CmdShootAlignSingle().withTimeout(2));
                 break;
             case "Billiards":
                 // initial position: (6.8, 6.272, 45 deg - should be approx. pointing straight at the ball to knock)
@@ -302,7 +286,7 @@ public class AutoPrograms {
     private SequentialCommandGroup IntakePathCmd(String trajectory) {
         ParallelDeadlineGroup movement = new ParallelDeadlineGroup(
                                             trajectoryCmd(trajectory), 
-                                            new CmdExtendIntakeAndRun());
+                                            new ScheduleCommand(new CmdExtendIntakeAndRun()));
         return new SequentialCommandGroup(new InstantCommand(intake::ejectIntake, intake), movement);
     }
 

--- a/src/main/java/frc/team3128/commands/CmdIntakeCargo.java
+++ b/src/main/java/frc/team3128/commands/CmdIntakeCargo.java
@@ -16,7 +16,7 @@ public class CmdIntakeCargo extends CommandBase{
         m_intake = Intake.getInstance();
         m_hopper = Hopper.getInstance();
 
-        addRequirements(m_intake);
+        addRequirements(m_intake, m_hopper);
     }
 
     @Override

--- a/src/main/java/frc/team3128/commands/CmdRetractHopper.java
+++ b/src/main/java/frc/team3128/commands/CmdRetractHopper.java
@@ -6,15 +6,18 @@ import edu.wpi.first.wpilibj2.command.WaitCommand;
 
 public class CmdRetractHopper extends WaitCommand {
     private Hopper m_hopper;
+    // TODO: change this to some better way of knowing it is retracted than a wait command
 
     /**
      * Runs hopper back to balls against intake and away from shooter flywheel
      * 
      * Intended to allow shooter to ramp up to speed
+     * @Requirements Hopper
      */
     public CmdRetractHopper() {
         super(0.5);
         m_hopper = Hopper.getInstance(); 
+        addRequirements(m_hopper);
     }
 
     @Override

--- a/src/main/java/frc/team3128/commands/CmdRetractHopper.java
+++ b/src/main/java/frc/team3128/commands/CmdRetractHopper.java
@@ -6,7 +6,6 @@ import edu.wpi.first.wpilibj2.command.WaitCommand;
 
 public class CmdRetractHopper extends WaitCommand {
     private Hopper m_hopper;
-    // TODO: change this to some better way of knowing it is retracted than a wait command
 
     /**
      * Runs hopper back to balls against intake and away from shooter flywheel

--- a/src/main/java/frc/team3128/commands/CmdShoot.java
+++ b/src/main/java/frc/team3128/commands/CmdShoot.java
@@ -1,7 +1,7 @@
 package frc.team3128.commands;
 
 import edu.wpi.first.wpilibj2.command.InstantCommand;
-import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import edu.wpi.first.wpilibj2.command.ProxyScheduleCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.team3128.subsystems.Hood;
 
@@ -13,7 +13,7 @@ public class CmdShoot extends SequentialCommandGroup {
      */
     public CmdShoot() {
         addCommands(
-            new CmdRetractHopper(),
+            new ProxyScheduleCommand(new CmdRetractHopper()),
             new CmdShootDist()
         );
     }
@@ -24,7 +24,7 @@ public class CmdShoot extends SequentialCommandGroup {
      */
     public CmdShoot(double RPM, double angle) {
         addCommands(
-            new CmdRetractHopper(),
+            new ProxyScheduleCommand(new CmdRetractHopper()),
             parallel (
                 new InstantCommand(() -> Hood.getInstance().startPID(angle), Hood.getInstance()),
                 new CmdShootRPM(RPM)

--- a/src/main/java/frc/team3128/commands/CmdShoot.java
+++ b/src/main/java/frc/team3128/commands/CmdShoot.java
@@ -15,7 +15,9 @@ public class CmdShoot extends SequentialCommandGroup {
      */
     public CmdShoot() {
         addCommands(
+            // run hopper back to push balls against intake
             new ProxyScheduleCommand(new CmdRetractHopper()),
+            // run hopper back at slower power to keep balls away from shooter until ready
             new ScheduleCommand(new InstantCommand(() -> Hopper.getInstance().runHopper(-0.1), Hopper.getInstance())),
             new CmdShootDist()
         );
@@ -27,7 +29,9 @@ public class CmdShoot extends SequentialCommandGroup {
      */
     public CmdShoot(double RPM, double angle) {
         addCommands(
+            // run hopper back to push balls against intake
             new ProxyScheduleCommand(new CmdRetractHopper()),
+            // run hopper back at slower power to keep balls away from shooter until ready
             new ScheduleCommand(new InstantCommand(() -> Hopper.getInstance().runHopper(-0.1), Hopper.getInstance())),
             parallel (
                 new InstantCommand(() -> Hood.getInstance().startPID(angle), Hood.getInstance()),

--- a/src/main/java/frc/team3128/commands/CmdShoot.java
+++ b/src/main/java/frc/team3128/commands/CmdShoot.java
@@ -2,8 +2,10 @@ package frc.team3128.commands;
 
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ProxyScheduleCommand;
+import edu.wpi.first.wpilibj2.command.ScheduleCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.team3128.subsystems.Hood;
+import frc.team3128.subsystems.Hopper;
 
 public class CmdShoot extends SequentialCommandGroup {
 
@@ -14,6 +16,7 @@ public class CmdShoot extends SequentialCommandGroup {
     public CmdShoot() {
         addCommands(
             new ProxyScheduleCommand(new CmdRetractHopper()),
+            new ScheduleCommand(new InstantCommand(() -> Hopper.getInstance().runHopper(-0.1), Hopper.getInstance())),
             new CmdShootDist()
         );
     }
@@ -25,11 +28,19 @@ public class CmdShoot extends SequentialCommandGroup {
     public CmdShoot(double RPM, double angle) {
         addCommands(
             new ProxyScheduleCommand(new CmdRetractHopper()),
+            new ScheduleCommand(new InstantCommand(() -> Hopper.getInstance().runHopper(-0.1), Hopper.getInstance())),
             parallel (
                 new InstantCommand(() -> Hood.getInstance().startPID(angle), Hood.getInstance()),
                 new CmdShootRPM(RPM)
             )
         );
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        super.end(interrupted);
+        // could also do .andThen()
+        new InstantCommand(() -> Hopper.getInstance().stopHopper(), Hopper.getInstance()).schedule();
     }
     
 }

--- a/src/main/java/frc/team3128/commands/CmdShoot.java
+++ b/src/main/java/frc/team3128/commands/CmdShoot.java
@@ -39,12 +39,5 @@ public class CmdShoot extends SequentialCommandGroup {
             )
         );
     }
-
-    @Override
-    public void end(boolean interrupted) {
-        super.end(interrupted);
-        // could also do .andThen()
-        new InstantCommand(() -> Hopper.getInstance().stopHopper(), Hopper.getInstance()).schedule();
-    }
     
 }

--- a/src/main/java/frc/team3128/commands/CmdShootAlign.java
+++ b/src/main/java/frc/team3128/commands/CmdShootAlign.java
@@ -25,12 +25,5 @@ public class CmdShootAlign extends SequentialCommandGroup {
             )
         );
     }
-
-    @Override
-    public void end(boolean interrupted) {
-        super.end(interrupted);
-        // could also do .andThen()
-        new InstantCommand(() -> Hopper.getInstance().stopHopper(), Hopper.getInstance()).schedule();
-    }
     
 }

--- a/src/main/java/frc/team3128/commands/CmdShootAlign.java
+++ b/src/main/java/frc/team3128/commands/CmdShootAlign.java
@@ -14,8 +14,11 @@ public class CmdShootAlign extends SequentialCommandGroup {
      */
     public CmdShootAlign() {
         addCommands(
+            // run hopper back to push balls against intake
             new ProxyScheduleCommand(new CmdRetractHopper()),
+            // run hopper back at slower power to keep balls away from shooter until ready
             new ScheduleCommand(new InstantCommand(() -> Hopper.getInstance().runHopper(-0.1), Hopper.getInstance())),
+            // align and shoot in parallel
             parallel (
                 new CmdAlign(),
                 new CmdShootDist()

--- a/src/main/java/frc/team3128/commands/CmdShootAlign.java
+++ b/src/main/java/frc/team3128/commands/CmdShootAlign.java
@@ -1,7 +1,10 @@
 package frc.team3128.commands;
 
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ProxyScheduleCommand;
+import edu.wpi.first.wpilibj2.command.ScheduleCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import frc.team3128.subsystems.Hopper;
 
 public class CmdShootAlign extends SequentialCommandGroup {
 
@@ -12,11 +15,19 @@ public class CmdShootAlign extends SequentialCommandGroup {
     public CmdShootAlign() {
         addCommands(
             new ProxyScheduleCommand(new CmdRetractHopper()),
+            new ScheduleCommand(new InstantCommand(() -> Hopper.getInstance().runHopper(-0.1), Hopper.getInstance())),
             parallel (
                 new CmdAlign(),
                 new CmdShootDist()
             )
         );
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        super.end(interrupted);
+        // could also do .andThen()
+        new InstantCommand(() -> Hopper.getInstance().stopHopper(), Hopper.getInstance()).schedule();
     }
     
 }

--- a/src/main/java/frc/team3128/commands/CmdShootAlignSingle.java
+++ b/src/main/java/frc/team3128/commands/CmdShootAlignSingle.java
@@ -1,7 +1,10 @@
 package frc.team3128.commands;
 
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ProxyScheduleCommand;
+import edu.wpi.first.wpilibj2.command.ScheduleCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import frc.team3128.subsystems.Hopper;
 
 public class CmdShootAlignSingle extends SequentialCommandGroup {
 
@@ -12,11 +15,19 @@ public class CmdShootAlignSingle extends SequentialCommandGroup {
     public CmdShootAlignSingle() {
         addCommands(
             new ProxyScheduleCommand(new CmdRetractHopper()),
+            new ScheduleCommand(new InstantCommand(() -> Hopper.getInstance().runHopper(-0.1), Hopper.getInstance())),
             parallel (
                 new CmdAlign(),
                 new CmdShootSingleBall()
             )
         );
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        super.end(interrupted);
+        // could also do .andThen()
+        new InstantCommand(() -> Hopper.getInstance().stopHopper(), Hopper.getInstance()).schedule();
     }
     
 }

--- a/src/main/java/frc/team3128/commands/CmdShootAlignSingle.java
+++ b/src/main/java/frc/team3128/commands/CmdShootAlignSingle.java
@@ -3,18 +3,18 @@ package frc.team3128.commands;
 import edu.wpi.first.wpilibj2.command.ProxyScheduleCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
-public class CmdShootAlign extends SequentialCommandGroup {
+public class CmdShootAlignSingle extends SequentialCommandGroup {
 
     /**
      * Align and shoot using the limelight approximated distance 
      * @Requirements Drivetrain, Shooter, Hood
      */
-    public CmdShootAlign() {
+    public CmdShootAlignSingle() {
         addCommands(
             new ProxyScheduleCommand(new CmdRetractHopper()),
             parallel (
                 new CmdAlign(),
-                new CmdShootDist()
+                new CmdShootSingleBall()
             )
         );
     }

--- a/src/main/java/frc/team3128/commands/CmdShootAlignSingle.java
+++ b/src/main/java/frc/team3128/commands/CmdShootAlignSingle.java
@@ -14,7 +14,9 @@ public class CmdShootAlignSingle extends SequentialCommandGroup {
      */
     public CmdShootAlignSingle() {
         addCommands(
+            // run hopper back to push balls against intake
             new ProxyScheduleCommand(new CmdRetractHopper()),
+            // run hopper back at slower power to keep balls away from shooter until ready
             new ScheduleCommand(new InstantCommand(() -> Hopper.getInstance().runHopper(-0.1), Hopper.getInstance())),
             parallel (
                 new CmdAlign(),

--- a/src/main/java/frc/team3128/commands/CmdShootAlignSingle.java
+++ b/src/main/java/frc/team3128/commands/CmdShootAlignSingle.java
@@ -24,12 +24,5 @@ public class CmdShootAlignSingle extends SequentialCommandGroup {
             )
         );
     }
-
-    @Override
-    public void end(boolean interrupted) {
-        super.end(interrupted);
-        // could also do .andThen()
-        new InstantCommand(() -> Hopper.getInstance().stopHopper(), Hopper.getInstance()).schedule();
-    }
     
 }

--- a/src/main/java/frc/team3128/commands/CmdShootDist.java
+++ b/src/main/java/frc/team3128/commands/CmdShootDist.java
@@ -3,7 +3,6 @@ package frc.team3128.commands;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.team3128.common.utility.Log;
 import frc.team3128.subsystems.Hood;
-import frc.team3128.subsystems.Hopper;
 import frc.team3128.subsystems.LimelightSubsystem;
 import frc.team3128.subsystems.Shooter;
 
@@ -11,7 +10,6 @@ public class CmdShootDist extends CommandBase {
     private Shooter shooter;
     private LimelightSubsystem limelights;
     private Hood hood;
-    private Hopper hopper;
 
     /**
      * Shoot through calculating the approximate distance to target via the limelight 
@@ -22,7 +20,6 @@ public class CmdShootDist extends CommandBase {
         shooter = Shooter.getInstance();
         limelights = LimelightSubsystem.getInstance();
         hood = Hood.getInstance();
-        hopper = Hopper.getInstance();
 
         addRequirements(shooter, hood);
     }
@@ -30,7 +27,6 @@ public class CmdShootDist extends CommandBase {
     @Override
     public void initialize() {
         limelights.turnShooterLEDOn();
-        hopper.runHopper(-0.1);
         shooter.resetPlateauCount();
     }
     
@@ -44,7 +40,6 @@ public class CmdShootDist extends CommandBase {
     @Override
     public void end(boolean interrupted) {
         shooter.stopShoot();
-        hopper.stopHopper();
         limelights.turnShooterLEDOff();
         Log.info("CmdShootDist", "Cancelling shooting");
     }

--- a/src/main/java/frc/team3128/commands/CmdShootRPM.java
+++ b/src/main/java/frc/team3128/commands/CmdShootRPM.java
@@ -3,12 +3,10 @@ package frc.team3128.commands;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.team3128.ConstantsInt;
 import frc.team3128.common.utility.Log;
-import frc.team3128.subsystems.Hopper;
 import frc.team3128.subsystems.Shooter;
 
 public class CmdShootRPM extends CommandBase {
     private Shooter shooter;
-    private Hopper hopper;
     private double rpm;
 
     /**
@@ -18,7 +16,6 @@ public class CmdShootRPM extends CommandBase {
      */
     public CmdShootRPM(double rpm) {
         shooter = Shooter.getInstance();
-        hopper = Hopper.getInstance();
         this.rpm = rpm;
 
         addRequirements(shooter);
@@ -29,13 +26,11 @@ public class CmdShootRPM extends CommandBase {
         // rpm = ConstantsInt.ShooterConstants.SET_RPM;
         shooter.resetPlateauCount();
         shooter.beginShoot(rpm);
-        hopper.runHopper(-0.1);
     }
     
     @Override
     public void end(boolean interrupted) {
         shooter.stopShoot();
-        hopper.stopHopper();
         Log.info("CmdShootRPM", "Cancelling shooting");
     }
     

--- a/src/main/java/frc/team3128/commands/CmdShootSingleBall.java
+++ b/src/main/java/frc/team3128/commands/CmdShootSingleBall.java
@@ -3,14 +3,12 @@ package frc.team3128.commands;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.team3128.common.utility.Log;
 import frc.team3128.subsystems.Hood;
-import frc.team3128.subsystems.Hopper;
 import frc.team3128.subsystems.LimelightSubsystem;
 import frc.team3128.subsystems.Shooter;
 
 public class CmdShootSingleBall extends CommandBase {
     private Shooter shooter;
     private LimelightSubsystem limelights;
-    private Hopper hopper;
     private Hood hood;
 
     private boolean prevIsReady = false;
@@ -26,14 +24,12 @@ public class CmdShootSingleBall extends CommandBase {
         shooter = Shooter.getInstance();
         limelights = LimelightSubsystem.getInstance();
         hood = Hood.getInstance();
-        hopper = Hopper.getInstance();
 
         addRequirements(shooter, hood);
     }
 
     @Override
     public void initialize() {
-        hopper.runHopper(-0.1);
         shooter.resetPlateauCount();
         limelights.turnShooterLEDOn();
     }
@@ -51,7 +47,6 @@ public class CmdShootSingleBall extends CommandBase {
     @Override
     public void end(boolean interrupted) {
         shooter.stopShoot();
-        hopper.stopHopper();
         limelights.turnShooterLEDOff();
         Log.info("CmdShootSingleBall", "Cancelling shooting");
     }


### PR DESCRIPTION
Use ScheduleCommand and ProxyScheduleCommand to schedule hopper commands so that hopper commands can require the hopper but will not end up with command groups with the hopper commands in them being yeeted (interrupted) when the hopper trigger command runs and requires the hopper